### PR TITLE
Fixes for usage with Puppetserver

### DIFF
--- a/lib/puppet/parser/functions/extlookup.rb
+++ b/lib/puppet/parser/functions/extlookup.rb
@@ -29,9 +29,8 @@ module Puppet::Parser::Functions
         config = YAML.load_file(configfile)
         parser = config[:parser] || "CSV"
 
-        require 'puppet/util/extlookup'
-
         relpath = File.join(File.dirname(__FILE__), "..", "..", "..")
+        require "#{relpath}/puppet/util/extlookup"
         require "#{relpath}/puppet/util/extlookup/#{parser.downcase}_parser"
 
         #parser = Kernel.const_get("Puppet").const_get("Util").const_get("Extlookup").const_get("#{parser}_Parser")

--- a/lib/puppet/util/extlookup.rb
+++ b/lib/puppet/util/extlookup.rb
@@ -40,7 +40,7 @@ module Puppet
                     tdata = data.clone
 
                     while tdata =~ /%\{(.+?)\}/
-                        var = $1
+                        var = $1.to_s
 
                         # if running in puppet we should make best use of the
                         # scope variable by using lookupvar, else maybe someone
@@ -48,9 +48,9 @@ module Puppet
                         # a Puppet scope.  Would have been handy if scope had a []
                         # alias to lookupvar really
                         if store.respond_to?(:lookupvar)
-                            tdata.gsub!(/%\{#{var}\}/, store.lookupvar(var))
+                            tdata.gsub!(/%\{#{var}\}/, store.lookupvar(var).to_s)
                         elsif store.respond_to?("[]")
-                            tdata.gsub!(/%\{#{var}\}/, store[var])
+                            tdata.gsub!(/%\{#{var}\}/, store[var].to_s)
                         else
                             raise("Don't know how to extract data from a store of type #{store.class}")
                         end


### PR DESCRIPTION
for those unlucky people out there with legacy code.

This made extlookup working for me on puppetserver 2.6.0.